### PR TITLE
Adding basic user challenge info to the active challenge page

### DIFF
--- a/lib/data/api.dart
+++ b/lib/data/api.dart
@@ -1,11 +1,14 @@
 import 'package:oauth2/oauth2.dart' as oauth2;
 import '../models/user.dart';
+import '../models/user_challenge.dart';
 import 'dart:convert';
 
 class RestDatasource {
-  static final baseUrl = "http://localhost:3000";
+  static final baseUrl2 = "http://localhost:3000";
+  static final baseUrl = "http://ec2-13-58-184-130.us-east-2.compute.amazonaws.com:3000";
   final tokenEndpoint = Uri.parse(baseUrl + "/oauth/token");
   final idEndpoint = Uri.parse(baseUrl + "/oauth/token/info");
+  final userChallengeEndpoint = baseUrl + "/api/v1/user_challenge";
 
   Future<User> login(String username, String password) async {
     oauth2.Client client;
@@ -26,5 +29,24 @@ class RestDatasource {
     }).whenComplete(client.close);
 
     return User(username, userId, credentials);
+  }
+
+  Future<List<UserChallenge>> getUserChallenges(User user) async {
+    List<UserChallenge> userChallenges;
+    oauth2.Client client = oauth2.Client(user.credentials);
+    var endpoint = Uri.parse(userChallengeEndpoint + "?user_id=${user.id}");
+
+    List<dynamic> body = await client.get(endpoint).then((response) {
+      return jsonDecode(response.body);
+    }).catchError((error) {
+      client.close();
+    }).whenComplete(client.close);
+    userChallenges = [];
+
+    body.forEach((challenge) {
+      userChallenges.add(UserChallenge.map(challenge));
+    });
+
+    return userChallenges;
   }
 }

--- a/lib/models/user_challenge.dart
+++ b/lib/models/user_challenge.dart
@@ -1,0 +1,40 @@
+class UserChallenge {
+  num id;
+  num userId;
+  num challengeId;
+  num statusId;
+
+  UserChallenge(this.id, this.userId, this.challengeId, this.statusId);
+
+  UserChallenge.map(dynamic obj) {
+    this.id = obj["id"];
+    this.userId = obj["user_id"];
+    this.challengeId = obj["challenge_id"];
+    this.statusId = obj["status_id"];
+  }
+
+  UserChallenge.fromJson(Map<String, dynamic> json) 
+    : id = json['id'],
+      userId = json['user_id'],
+      challengeId = json['challenge_id'],
+      statusId = json['challenge_id'];
+
+  Map<String, dynamic> toMap() {
+    var map = Map<String, dynamic>();
+    map["id"] = id;
+    map["user_id"] = userId;
+    map["challenge_id"] = challengeId;
+    map["status_id"] = statusId;
+    return map;
+  }
+
+  @override
+  String toString() {
+    return "{ UserChallenge - " +
+      "id: $id, " +
+      "userId: $userId, " +
+      "challengeId: $challengeId " +
+      "statusId: $statusId " +
+      "}";
+  }
+}

--- a/lib/models/user_challenge.dart
+++ b/lib/models/user_challenge.dart
@@ -13,12 +13,6 @@ class UserChallenge {
     this.statusId = obj["status_id"];
   }
 
-  UserChallenge.fromJson(Map<String, dynamic> json) 
-    : id = json['id'],
-      userId = json['user_id'],
-      challengeId = json['challenge_id'],
-      statusId = json['challenge_id'];
-
   Map<String, dynamic> toMap() {
     var map = Map<String, dynamic>();
     map["id"] = id;

--- a/lib/screens/challenges/active.dart
+++ b/lib/screens/challenges/active.dart
@@ -1,10 +1,29 @@
 import 'package:flutter/material.dart';
+import '../../models/user_challenge.dart';
 
 class ActiveChallengeWidget extends StatelessWidget {
+  final List<UserChallenge> userChallenges;
+
+  ActiveChallengeWidget({Key key, this.userChallenges});
+
   @override
   Widget build(BuildContext context) {
     return Container(
-      child: Text('Active Challenges'),
+      child: ListView.builder(
+        itemCount: userChallenges.length,
+        itemBuilder: (context, index) {
+          final challenge = userChallenges[index];
+          return ListTile(
+            title: Text(
+              "ID: ${challenge.id}",
+              style: Theme.of(context).textTheme.headline,
+            ),
+            subtitle: Text(
+              "Challenge_id: ${challenge.userId}, Status: ${challenge.statusId}"
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/challenges/challenges.dart
+++ b/lib/screens/challenges/challenges.dart
@@ -1,20 +1,36 @@
 import 'package:flutter/material.dart';
 import 'active.dart';
 import 'completed.dart';
+import '../../models/user.dart';
+import '../../models/user_challenge.dart';
+import '../../data/api.dart';
 
 class ChallengeScreen extends StatefulWidget {
+  final User user;
+
+  ChallengeScreen({Key key , this.user});
+
   @override
   State createState() => ChallengeScreenState();
 }
 
 class ChallengeScreenState extends State<ChallengeScreen> {
-  final List<Widget> _pages = [
-    ActiveChallengeWidget(),
-    CompletedChallengeWidget()
-  ];
+
+  RestDatasource _api = RestDatasource();
+  List<UserChallenge> userChallenges;
 
   @override
   Widget build(BuildContext context) {
+
+    _api.getUserChallenges(widget.user).then((challenges) {
+      userChallenges = challenges;
+    });
+
+    List<Widget> _pages = [
+      ActiveChallengeWidget(userChallenges: this.userChallenges),
+      CompletedChallengeWidget()
+    ];
+
     return DefaultTabController(
       length: 2,
       child: Scaffold(

--- a/lib/screens/navigation.dart
+++ b/lib/screens/navigation.dart
@@ -27,7 +27,7 @@ class NavigationScreenState extends State<NavigationScreen> {
     
     List<Widget> _children = [
       HomeWidget(),
-      ChallengeScreen(),
+      ChallengeScreen(user: widget.user),
       ProfileWidget(user: widget.user)
     ];
 


### PR DESCRIPTION
Pulling the user challenge info from the backend, and displaying it on the active challenges tab. There is an issue with WHEN I am pulling the challenges, as right now I am doing so at the same time as rendering the challenge page, which causes a big error until you refresh the page (see pictures below). Tapping on the challenge tab should resolve the issue, but I will fix this properly before merging the PR.

On initial load:
![image](https://user-images.githubusercontent.com/19960884/51865492-69089900-2314-11e9-97ef-515b2f073a9f.png)

After second load:
![image](https://user-images.githubusercontent.com/19960884/51865476-5bebaa00-2314-11e9-838a-1d8de60d82ed.png)
