### PR TITLE
Fixing the async issues with challenge loading

### DIFF
--- a/lib/data/api.dart
+++ b/lib/data/api.dart
@@ -5,7 +5,7 @@ import 'dart:convert';
 
 class RestDatasource {
   static final baseUrl2 = "http://localhost:3000";
-  static final baseUrl = "http://ec2-13-58-184-130.us-east-2.compute.amazonaws.com:3000";
+  static final baseUrl = "https://api.thesci.net/";
   final tokenEndpoint = Uri.parse(baseUrl + "/oauth/token");
   final idEndpoint = Uri.parse(baseUrl + "/oauth/token/info");
   final userChallengeEndpoint = baseUrl + "/api/v1/user_challenge";

--- a/lib/screens/challenges/active.dart
+++ b/lib/screens/challenges/active.dart
@@ -17,7 +17,7 @@ class ActiveChallengeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return userChallenges == null ? loadingIndicator : Container(
+    Container challengeList = Container(
       child: ListView.builder(
         itemCount: userChallenges.length,
         itemBuilder: (context, index) {
@@ -34,5 +34,7 @@ class ActiveChallengeWidget extends StatelessWidget {
         },
       ),
     );
+
+    return userChallenges == null ? loadingIndicator : challengeList;
   }
 }

--- a/lib/screens/challenges/active.dart
+++ b/lib/screens/challenges/active.dart
@@ -6,9 +6,18 @@ class ActiveChallengeWidget extends StatelessWidget {
 
   ActiveChallengeWidget({Key key, this.userChallenges});
 
+  final loadingIndicator = Column(
+    children: [
+      Padding(
+        padding: EdgeInsets.symmetric(vertical: 100.0),
+        child: CircularProgressIndicator()
+      )
+    ]
+  );
+
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return userChallenges == null ? loadingIndicator : Container(
       child: ListView.builder(
         itemCount: userChallenges.length,
         itemBuilder: (context, index) {
@@ -19,7 +28,7 @@ class ActiveChallengeWidget extends StatelessWidget {
               style: Theme.of(context).textTheme.headline,
             ),
             subtitle: Text(
-              "Challenge_id: ${challenge.userId}, Status: ${challenge.statusId}"
+              "challenge_id: ${challenge.challengeId}, Status: ${challenge.statusId}"
             ),
           );
         },

--- a/lib/screens/challenges/challenges.dart
+++ b/lib/screens/challenges/challenges.dart
@@ -23,11 +23,15 @@ class ChallengeScreenState extends State<ChallengeScreen> {
   Widget build(BuildContext context) {
 
     _api.getUserChallenges(widget.user).then((challenges) {
-      userChallenges = challenges;
+      if(this.mounted) {
+        setState(() => userChallenges = challenges);
+      }
     });
 
     List<Widget> _pages = [
-      ActiveChallengeWidget(userChallenges: this.userChallenges),
+      ActiveChallengeWidget(
+        userChallenges: this.userChallenges
+      ),
       CompletedChallengeWidget()
     ];
 

--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -6,6 +6,10 @@ class HomeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final greenText =TextStyle(
+      color: Colors.green
+    );
+
     return Scaffold(
       appBar: AppBar(
         title: Text("Home"),
@@ -16,24 +20,22 @@ class HomeWidget extends StatelessWidget {
           child: Column(
             children: <Widget>[
               Text(
-                "Welcome to",
+                "Welcome Sustainable Citizen!",
                 textScaleFactor: 3.0,
                 textAlign: TextAlign.center,
+                style: greenText,
               ),
               Text(
-                "Sustainable Citizen!",
-                textScaleFactor: 4.0,
-                textAlign: TextAlign.center,
-              ),
-              Text(
-                "\nThank you for being a member of the Sustainable Citizen testing team!",
+                "\nThis app will guide you towards your sustainable goals and become an eco leader within your community!",
                 textScaleFactor: 2.0,
                 textAlign: TextAlign.center,
+                style: greenText,
               ),
               Text(
-                "\nCheck out your challenges to get started.Make sure you record when you complete them!\n",
+                "\nAre you ready for your first challenge?\n",
                 textScaleFactor: 1.5,
                 textAlign: TextAlign.center,
+                style: greenText,
               ),
               new Icon(arrow_downward),
             ],

--- a/lib/screens/login/login.dart
+++ b/lib/screens/login/login.dart
@@ -125,8 +125,9 @@ class LoginFormState extends State<LoginForm>
           ),
         ),
         Padding(
-            padding: EdgeInsets.symmetric(vertical: 16.0),
-            child: _isLoading ? CircularProgressIndicator() : loginButton),
+          padding: EdgeInsets.symmetric(vertical: 16.0),
+          child: _isLoading ? CircularProgressIndicator() : loginButton
+        ),
       ],
     );
 

--- a/lib/screens/navigation.dart
+++ b/lib/screens/navigation.dart
@@ -14,11 +14,11 @@ class NavigationScreen extends StatefulWidget {
 }
 
 class NavigationScreenState extends State<NavigationScreen> {
-  int _currentIndex = 0;
+  int _index = 0;
 
-  void onTabTapped(int index) {
+  void onTabTapped(int newIndex) {
     setState(() {
-      _currentIndex = index;
+      _index = newIndex;
     });
   }
 
@@ -32,10 +32,10 @@ class NavigationScreenState extends State<NavigationScreen> {
     ];
 
     return Scaffold(
-      body: _children[_currentIndex],
+      body: _children[_index],
       bottomNavigationBar: BottomNavigationBar(
         onTap: onTabTapped,
-        currentIndex: _currentIndex,
+        currentIndex: _index,
         items: [
           BottomNavigationBarItem(
             icon: Icon(Icons.home),


### PR DESCRIPTION
When navigating the the active challenges page, you will see that there is a spinning loading icon which is present until the list of challenges has been loaded.

Currently this list is re-fetched through the api every time you revisit the challenge tab, however it is NOT reloaded when switching between the active and completed sections of the challenge page.
